### PR TITLE
Fixed caching (not final solution but it works for now) and q-expansion and number field display.

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
@@ -39,14 +39,20 @@ try:
 except:
     emf_logger.critical("Could not import dirichlet_conrey!")
 
-def newform_label(level, weight, character, label, embedding=None):
+def newform_label(level, weight, character, label, embedding=None, make_cache_label=False):
+    l = ''
+    if make_cache_label:
+        l = 'emf.'
     if embedding is None:
-        return "{0}.{1}.{2}{3}".format(level, weight, character, label)
+        l += "{0}.{1}.{2}{3}".format(level, weight, character, label)
     else:
-        return "{0}.{1}.{2}{3}.{4}".format(level, weight, character, label, embedding)
+        l += "{0}.{1}.{2}{3}.{4}".format(level, weight, character, label, embedding)
 
-def space_label(level, weight, character):
-    return "{0}.{1}.{2}".format(level, weight, character)
+def space_label(level, weight, character, make_cache_label=False):
+    l = ''
+    if make_cache_label:
+        l = 'emf.'
+    return l+"{0}.{1}.{2}".format(level, weight, character)
 
 def parse_range(arg, parse_singleton=int):
     # TODO: graceful errors

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_utils.py
@@ -31,6 +31,8 @@ from lmfdb.modular_forms.backend.mf_utils import my_get
 from plot_dom import draw_fundamental_domain
 import lmfdb.base
 from bson.binary import *
+from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty
+from lmfdb.utils import web_latex_split_on_re, web_latex_split_on_pm
 
 try:
     from dirichlet_conrey import *
@@ -358,3 +360,30 @@ def dimension_from_db(level,weight,chi=None,group='gamma0'):
         for i in dtable.keys():
             res[level][weight][int(i)] = dtable[i]
         return res
+
+def field_label(F, pretty = True, check=False):
+    r"""
+      Returns the LMFDB label of the field F.
+    """
+    if F.degree() == 1:
+        p = 'x'
+    else:
+        pp = F.polynomial()
+        x = pp.parent().gen()
+        p = str(pp).replace(str(x), 'x')
+    l = poly_to_field_label(p)
+    if l is None:
+        if check:
+            return False
+        else:
+            if pretty:
+                return web_latex_split_on_pm(pp)
+            else:
+                return pp
+    else:
+        if check:
+            return True
+    if pretty:
+        return field_pretty(l)
+    else:
+        return l

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -107,8 +107,8 @@ class WebHeckeOrbits(WebDict):
         from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached,WebNewForm
         res = {}
         for lbl in l:
-            #F = WebNewForm(self.level, self.weight, self.character, lbl, parent=self.parent)
-            F = WebNewForm_cached(self.level, self.weight, self.character, lbl, parent=self.parent)
+            F = WebNewForm(self.level, self.weight, self.character, lbl, parent=self.parent)
+            #F = WebNewForm_cached(self.level, self.weight, self.character, lbl, parent=self.parent)
             emf_logger.debug("Got F for label {0} : {1}".format(lbl,F))
             res[lbl]=F
 #            return {lbl : WebNewForm_cached(self.level, self.weight, self.character, lbl, parent=self.parent)

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -245,7 +245,7 @@ from lmfdb.utils import cache
 from lmfdb.modular_forms.elliptic_modular_forms import use_cache
 def WebModFormSpace_cached(level,weight,character,**kwds):
     if use_cache: 
-        label = space_label(level, weight, character)
+        label = space_label(level, weight, character, make_cache_label = True)
         M= cache.get(label)
         emf_logger.critical("Looking for cached space:{0}".format(label))
         if M is None:

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_modform_space.py
@@ -128,6 +128,7 @@ class WebModFormSpace(WebObject, CachedRepresentation):
 
     EXAMPLES::
     - We assume that we are starting from scratch.
+    TODO: UPDATE THIS documentation! It is quite old. M.newforms has been replaced by M.hecke_orbits and takes WebNewForm objects.
 
     sage: M=WebModFormSpace(1,12)
     sage: M.galois_orbit_name

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
@@ -54,15 +54,14 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import
      WebModFormSpaceProperty
      )
 
-from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label, space_label
+from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label, space_label, field_label
+
+from lmfdb.utils import web_latex_split_on_re
 
 from lmfdb.modular_forms.elliptic_modular_forms import (
      emf_version,
      emf_logger
      )
-
-from lmfdb.number_fields.number_field import poly_to_field_label, field_pretty
-from lmfdb.utils import web_latex_split_on_re
 
 from sage.rings.number_field.number_field_base import (
      NumberField
@@ -469,46 +468,31 @@ class WebNewForm(WebObject, CachedRepresentation):
     def url(self):
         return url_for('emf.render_elliptic_modular_forms', level=self.level, weight=self.weight, character=self.character.number, label=self.label)
 
-    def coefficient_field_label(self, pretty = True):
+    def coefficient_field_label(self, pretty = True, check=False):
         r"""
           Returns the LMFDB label of the (absolute) coefficient field (if it exists).
         """
         F = self.coefficient_field
-        #emf_logger.debug("pol={0}".format(p))
-        if F.degree() == 1:
-            p = 'x'
-        else:
-            p = F.polynomial()
-        l = poly_to_field_label(p)
-        if l is None:
-            return ''        
-        if pretty:
-            return field_pretty(l)
-        else:
-            return l
+        return field_label(F, pretty, check)
 
     def coefficient_field_url(self):
-        return url_for("number_fields.by_label", label=self.coefficient_field_label(pretty = False))
+        if self.coefficient_field_label(check=True):
+            return url_for("number_fields.by_label", label=self.coefficient_field_label(pretty = False))
+        else:
+            return ''
 
-    def base_field_label(self, pretty = True):
+    def base_field_label(self, pretty = True, check=False):
         r"""
           Returns the LMFDB label of the base field.
         """
         F = self.base_ring
-        if F.degree() == 1:
-            p = 'x'
-        else:
-            p = F.polynomial()
-        l = poly_to_field_label(p)
-        if l is None:
-            return ''
-        if pretty:
-            return field_pretty(l)
-        else:
-            return l
+        return field_label(F, pretty, check)
 
     def base_field_url(self):
-        return url_for("number_fields.by_label", label=self.base_field_label(pretty = False))
+        if self.base_field_label(check=True):
+            return url_for("number_fields.by_label", label=self.base_field_label(pretty = False))
+        else:
+            return ''
 
 
 from sage.all import cached_function,AlphabeticStrings

--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/web_newforms.py
@@ -51,7 +51,8 @@ from lmfdb.modular_forms.elliptic_modular_forms.backend.web_character import (
      )
 
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import (
-     WebModFormSpaceProperty
+     WebModFormSpaceProperty,
+     WebModFormSpace_cached
      )
 
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import newform_label, space_label, field_label
@@ -516,20 +517,8 @@ from lmfdb.modular_forms.elliptic_modular_forms import use_cache
 
 def WebNewForm_cached(level,weight,character,label,parent=None, **kwds):
     if use_cache: 
-        nlabel = newform_label(level, weight, character, label)
-        F= cache.get(nlabel)
-        emf_logger.critical("Looking for cached form:{0}".format(nlabel))
-        if F is None:
-            emf_logger.debug("F was not in cache!")
-            F = WebNewForm(level,weight,character,label,parent=parent,**kwds)
-            emf_logger.debug("Computed F")
-            try:
-                cache.set(nlabel, F , timeout=15 * 60) # keep 15 minutes
-            except Exception as e:
-                print e.message
-            emf_logger.debug("Inserted F in cache!")
-        else:
-            emf_logger.critical("F was in cache!")
+        M = WebModFormSpace_cached(level, weight, character)
+        return M.hecke_orbits[label]
     else:
         F = WebNewForm(level,weight,character,label,**kwds)
         emf_logger.critical("Computed F not using cache!")

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -163,7 +163,7 @@ def get_qexp(level, weight, character, label, prec, latex=False, **kwds):
         if not latex:
             c = WNF.q_expansion
         else:
-            c = WNF.q_expansion_latex(prec=prec)
+            c = WNF.q_expansion_latex(prec=prec, name = 'a')
         return c
     except Exception as e:
         return "<span style='color:red;'>ERROR: %s</span>" % e.message

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -25,6 +25,7 @@ from lmfdb.base import app, db
 from lmfdb.modular_forms.backend.mf_utils import my_get
 from lmfdb.utils import to_dict
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf
+from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
 from lmfdb.modular_forms.elliptic_modular_forms.backend.emf_utils import render_fd_plot,extract_data_from_jump_to
 from emf_render_web_newform import render_web_newform
 from emf_render_web_modform_space import render_web_modform_space
@@ -146,6 +147,31 @@ def render_plot(grouptype=0, level=1):
     response.headers['Content-type'] = 'image/png'
     return response
 
+@emf.route("/Qexp/<int:level>/<int:weight>/<int:character>/<label>/<int:prec>")
+def get_qexp(level, weight, character, label, prec, latex=False, **kwds):
+    emf_logger.debug(
+        "get_qexp for: level={0},weight={1},character={2},label={3}".format(level, weight, character, label))
+    #latex = my_get(request.args, "latex", False, bool)
+    emf_logger.debug(
+        "get_qexp latex: {0}, prec: {1}".format(latex, prec))
+    #if not arg:
+    #    return flask.abort(404)
+    try:
+        M = WebModFormSpace_cached(level=level,weight=weight,character=character)
+        WNF = M.hecke_orbits[label]
+        WNF.prec = prec
+        if not latex:
+            c = WNF.q_expansion
+        else:
+            c = WNF.q_expansion_latex(prec=prec)
+        return c
+    except Exception as e:
+        return "<span style='color:red;'>ERROR: %s</span>" % e.message
+
+@emf.route("/qexp_latex/<int:level>/<int:weight>/<int:character>/<label>/<int:prec>")
+@emf.route("/qexp_latex/<int:level>/<int:weight>/<int:character>/<label>/")
+def get_qexp_latex(level, weight, character, label, prec=10, **kwds):
+    return get_qexp(level, weight, character, label, prec, latex=True, **kwds)
 
 ## By including this we get additional routes which we use to test various new features
 from experimental import *

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -22,7 +22,7 @@ AUTHOR: Fredrik Strömberg  <fredrik314@gmail.com>
 from flask import render_template, url_for, send_file
 from lmfdb.utils import to_dict 
 from sage.all import uniq
-from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
+from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached, WebModFormSpace
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP
 ###
 ###

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space.py
@@ -110,7 +110,8 @@ def set_info_for_modular_form_space(level=None, weight=None, character=None, lab
     for label in WMFS.hecke_orbits:
         f = WMFS.hecke_orbits[label]
         friends.append(('Number field ' + f.base_field_label(), f.base_field_url()))
-        friends.append(('Number field ' + f.coefficient_field_label(), f.coefficient_field_url()))
+        if f.coefficient_field_label(check=True):
+            friends.append(('Number field ' + f.coefficient_field_label(), f.coefficient_field_url()))
     friends.append(("Dirichlet character \(" + WMFS.character.latex_name + "\)", WMFS.character.url()))
     friends = uniq(friends)
     info['friends'] = friends

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
@@ -24,7 +24,7 @@ from lmfdb.utils import to_dict
 from sage.all import uniq
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace
 from lmfdb.modular_forms.elliptic_modular_forms import EMF, emf_logger, emf, EMF_TOP
-from lmfdb.modular_forms.elliptic_modular_forms.backend.cached_interfaces import WebModFormSpace_cached
+#from lmfdb.modular_forms.elliptic_modular_forms.backend.cached_interfaces import WebModFormSpace_cached
 
 ###
 ###

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -64,8 +64,7 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     emf_logger.debug("PREC: {0}".format(prec))
     emf_logger.debug("BITPREC: {0}".format(bprec))    
     try:
-        M = WebModFormSpace_cached(level=level,weight=weight,character=character)
-        WNF = M.hecke_orbits[label]
+        WNF = WebNewForm_cached(level=level, weight=weight, character=character, label=label)
         emf_logger.critical("defined webnewform for rendering!")
         # if info.has_key('download') and info.has_key('tempfile'):
         #     WNF._save_to_file(info['tempfile'])

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -23,7 +23,7 @@ AUTHORS:
 """
 from flask import render_template, url_for,  send_file
 from sage.all import version,uniq,ZZ,Cusp,Infinity,latex,QQ
-from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached
+from lmfdb.modular_forms.elliptic_modular_forms.backend.web_newforms import WebNewForm_cached, WebNewForm
 from lmfdb.modular_forms.elliptic_modular_forms.backend.web_modform_space import WebModFormSpace_cached
 from lmfdb.utils import to_dict,ajax_more
 from lmfdb.modular_forms.backend.mf_utils import my_get
@@ -65,8 +65,8 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     emf_logger.debug("BITPREC: {0}".format(bprec))    
     try:
         M = WebModFormSpace_cached(level=level,weight=weight,character=character)
-        WNF = WebNewForm_cached(level=level,weight=weight, character=character, label=label,parent=M)
-        emf_logger.critical("defned webnewform for rendering!")
+        WNF = M.hecke_orbits[label]
+        emf_logger.critical("defined webnewform for rendering!")
         # if info.has_key('download') and info.has_key('tempfile'):
         #     WNF._save_to_file(info['tempfile'])
         #     info['filename']=str(weight)+'-'+str(level)+'-'+str(character)+'-'+label+'.sobj'
@@ -118,7 +118,8 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
         rdeg = WNF.coefficient_field.relative_degree()
     if cdeg==1:
         info['satake'] = WNF.satake
-    info['qexp'] = ajax_more(WNF.q_expansion_latex,{'prec':10,'name':'a'},{'prec':20,'name':'a'},{'prec':100,'name':'a'},{'prec':200,'name':'a'})
+    info['qexp'] = WNF.q_expansion_latex(prec=10, name='a')
+    info['qexp_display'] = url_for(".get_qexp_latex", level=level, weight=weight, character=character, label=label)
     
     # info['qexp'] = WNF.q_expansion_latex(prec=prec)
     #c_pol_st = str(WNF.absolute_polynomial)
@@ -285,17 +286,25 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
 import flask
 
 
-@emf.route("/Qexp/<int:level>/<int:weight>/<int:character>/<label>")
-def get_qexp(level, weight, character, label, **kwds):
-    emf_logger.debug(
-        "get_qexp for: level={0},weight={1},character={2},label={3}".format(level, weight, character, label))
-    prec = my_get(request.args, "prec", default_prec, int)
-    if not arg:
-        return flask.abort(404)
-    try:
-        WNF = WebNewForm_cached(level, weight, chi=character, label=label, prec=prec, verbose=2)
-        nc = max(prec, 5)
-        c = WNF.print_q_expansion(nc)
-        return c
-    except Exception as e:
-        return "<span style='color:red;'>ERROR: %s</span>" % e.message
+## @emf.route("/Qexp/<int:level>/<int:weight>/<int:character>/<label>")
+## def get_qexp(level, weight, character, label, **kwds):
+##     emf_logger.debug(
+##         "get_qexp for: level={0},weight={1},character={2},label={3}".format(level, weight, character, label))
+##     prec = my_get(request.args, "prec", default_prec, int)
+##     latex = my_get(request.args, "latex", False, bool)
+##     if not arg:
+##         return flask.abort(404)
+##     try:
+##         WNF = WebNewForm(level, weight, chi=character, label=label, prec=prec, verbose=2)
+##         nc = max(prec, 5)
+##         if not latex:
+##             c = WNF.print_q_expansion(nc)
+##         else:
+##             c = WNF.q_expansion_latex(nc)
+##         return c
+##     except Exception as e:
+##         return "<span style='color:red;'>ERROR: %s</span>" % e.message
+
+## @emf.route("/qexp_latex/<int:level>/<int:weight>/<int:character>/<label>")
+## def get_qexp_latex(level, weight, character, label, **kwds):
+##     return get_qexp(level, weight, character, label, latex=True, **kwds)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_newform.py
@@ -91,7 +91,8 @@ def set_info_for_web_newform(level=None, weight=None, character=None, label=None
     friends = list()
     space_url = url_for('emf.render_elliptic_modular_forms',level=level, weight=weight, character=character)
     friends.append(('\( S_{%s}(%s, %s)\)'%(WNF.weight, WNF.level, WNF.character.latex_name), space_url))
-    friends.append(('Number field ' + WNF.coefficient_field_label(), WNF.coefficient_field_url()))
+    if WNF.coefficient_field_label(check=True):
+        friends.append(('Number field ' + WNF.coefficient_field_label(), WNF.coefficient_field_url()))
     friends.append(('Number field ' + WNF.base_field_label(), WNF.base_field_url()))
     friends = uniq(friends)
     friends.append(("Dirichlet character \(" + WNF.character.latex_name + "\)", WNF.character.url()))

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -38,15 +38,15 @@
 {% else %}
 
 {% if extra_info is defined %}
-<span style="font-size:50%">({{ extra_info |safe }})</span>
+<span style="font-size:50%">({{ extra_info | safe }})</span>
 {% endif %}
-{{ space | safe }}
+
 {% if space.dimension_new_cusp_forms > 0 %}
 <style>
 table.td.center {text-align : center;}
 </style>
 <h2>
-  Decomposition of {{name_new}} into {{ KNOWL('mf.elliptic.hecke-orbits',title='irreducible Hecke orbits')}}
+  Decomposition of {{new_name}} into {{ KNOWL('mf.elliptic.hecke-orbits',title='irreducible Hecke orbits')}}
 </h2>
 {% if  space.hecke_orbits=={} %}
    Problem with Hecke orbits in the datbase!
@@ -88,7 +88,7 @@ table.td.center {text-align : center;}
 {% endif %}
 
 {% if space.oldspace_decomposition != {} and space.dimension_cusp_forms > space.dimension_new_cusp_forms %}
-<h2> Decomposition of {{name_old}} into {{ KNOWL('mf.elliptic.oldspace',title='lower level spaces')}}</h2>
+<h2> Decomposition of {{old_name}} into {{ KNOWL('mf.elliptic.oldspace',title='lower level spaces')}}</h2>
 {{ space.oldspace_decomposition | safe }}
 {% endif %}
 	

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -19,13 +19,14 @@
         <div class="output">
           <span id="qexp_display">{{ qexp | safe }}</span>
         </div>
-        <div class="emptyspace"><br>
+	<div class="output">{{ polynomial_st | safe }}
+	</div>
+	<div class="emptyspace"><br>
         </div>
         <button id="morebutton">Show more coefficients</button>
     </form>
 </div>
 </div>
-{{ polynomial_st | safe }}
 <br>
 {% if is_rational==0 %}
 

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -13,8 +13,17 @@
 {% else %}
 
 <div id="qexp">
-<h2> {{ KNOWL('mf.elliptic.q-expansion',title='q-expansion')}}</h2>
-{{ qexp | safe }}
+  <h2> {{ KNOWL('mf.elliptic.q-expansion',title='q-expansion')}}</h2>
+  <div>
+    <form>
+        <div class="output">
+          <span id="qexp_display">{{ qexp | safe }}</span>
+        </div>
+        <div class="emptyspace"><br>
+        </div>
+        <button id="morebutton">Show more coefficients</button>
+    </form>
+</div>
 </div>
 {{ polynomial_st | safe }}
 <br>
@@ -244,8 +253,20 @@ We have {{ max_cn }} coefficients available from the database.
 
 <h2>{{ KNOWL_INC(KNOWL_ID+'.bottom', title='') }}</h2>
 
-
-
-
+<script type="text/javascript">
+var number_of_coefficients = 10;
+function more_handler(evt) {
+    number_of_coefficients += number_of_coefficients;
+    evt.preventDefault();
+    $("#qexp_display").load("{{qexp_display}}"+number_of_coefficients,
+        function() {
+            {# tell mathjx to render the output #}
+            MathJax.Hub.Queue(['Typeset', MathJax.Hub, "qexp_display"]);
+        });
+}
+$(function() {
+    $("#morebutton").click(function(e) {more_handler(e)});
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
* The caching has been fixed temporarily by only effectively caching spaces and calling .hecke_orbits on them to access the forms by label
* The q-expansion display has been fixed to only display as many coefficients as are available without computing anything (this has to be redone again but at least it doesn't show any wrong results anymore)
    * For this I used the same technique that is used on the elliptic curves pages and introduced a new url /qexp_latex/...
    * I also moved the /Qexp url and inserted the /qexp_latex/ url handlers into emf_main.py because it didn't work immediately. I'm not sure if this is the best way to do it.