### PR TITLE
small changes to degree 2 L-functions for cusp form browse page,…

### DIFF
--- a/lmfdb/lfunctions/templates/cuspformGL2.html
+++ b/lmfdb/lfunctions/templates/cuspformGL2.html
@@ -2,27 +2,31 @@
 {% block content %}
 
 <div>
-This is the browse of the L-functions associated to
-{{ KNOWL("mf.elliptic.newform",title="newforms")}} \(f\) on Hecke congruence groups
-$\Gamma_0(N)$ with trivial character.
-These L-functions \(L(s,f) = \sum a_n n^{-s} \) have an
-{{ KNOWL('lfunction.euler_product', title='Euler product')}}
-of the form
-\[
-   L(s,f)= \prod_{p\mid N}  \left(1 - a_p p^{-s} \right)^{-1}\prod_{p\nmid N}  \left(1 - a_p p^{-s} + p^{-2s} \right)^{-1}
-\]
-and satisfy the
-{{ KNOWL("lfunction.functional_equation",title="functional equation")}} of the form
-\begin{equation}
-\Lambda(s,f) = N^{s/2} \Gamma_{\mathbb{C} }
-\left(s + \frac{k-1}{2} \right)\cdot L(s, f) =
-\varepsilon \Lambda(1-s,f),
-\end{equation}
-where  $N$ is the
-{{ KNOWL("mf.elliptic.level",title="level")}}, $k$ is the
-{{ KNOWL("mf.elliptic.weight",title="weight")}}
-and \(a_n n^{\frac{k-1}{2} } \)
-are algebraic integers. The number \(\varepsilon\) is equal to \(i^k \varepsilon_N\) where \(\varepsilon_N\) is  the {{KNOWL("mf.elliptic.fricke",title="Fricke eigenvalue")}} of \(f\), and so is equal to either \(+1\) or \(-1\) since these L-functions are associated to the trivial character. It is therefore called the {{ KNOWL('lfunction.sign', title='sign')}} of the L-function.
+<h3>
+Browse L-functions associated to {{
+KNOWL("mf.elliptic.newform",title="newforms")}} \(f\) on Hecke
+congruence groups $\Gamma_0(N)$ with trivial character:
+</h3>
+</p>
+These L-functions \(L(s,f) = \sum a_n n^{-s} \) have an {{
+KNOWL('lfunction.euler_product', title='Euler product')}} of the form
+\[ L(s,f)= \prod_{p\mid N} \left(1 - a_p p^{-s}
+\right)^{-1}\prod_{p\nmid N} \left(1 - a_p p^{-s} + p^{-2s}
+\right)^{-1} \] and satisfy the {{
+KNOWL("lfunction.functional_equation",title="functional equation")}}
+of the form \begin{equation} \Lambda(s,f) = N^{s/2} \Gamma_{\mathbb{C}
+} \left(s + \frac{k-1}{2} \right)\cdot L(s, f) = \varepsilon
+\Lambda(1-s,f), \end{equation} where $N$ is the {{
+KNOWL("mf.elliptic.level",title="level")}}, $k$ is the {{
+KNOWL("mf.elliptic.weight",title="weight")}} and \(a_n
+n^{\frac{k-1}{2} } \) are algebraic integers. Here,
+\(\varepsilon = i^k \varepsilon_N\), where
+\(\varepsilon_N\) is the {{KNOWL("mf.elliptic.fricke",title="Fricke
+eigenvalue")}} of \(f\), and so is equal to either \(+1\) or \(-1\)
+since these L-functions are associated to the trivial character. It is
+therefore called the {{ KNOWL('lfunction.sign', title='sign')}} of the
+L-function.
+<p>
 </div>
 <br>
 <div>

--- a/lmfdb/test_lfunction.py
+++ b/lmfdb/test_lfunction.py
@@ -103,7 +103,7 @@ class LfunctionTest(LmfdbTest):
 
     def test_Ldegree2CuspForm(self):
         L = self.tc.get('/L/degree2/CuspForm/')
-        assert 'Holomorphic' in L.data
+        assert 'trivial character' in L.data
 
     def test_Ldegree2MaassForm(self):
         L = self.tc.get('/L/degree2/MaassForm/')


### PR DESCRIPTION
…improved wording and revised test

L/degree2/CuspForm/ has a test which needed fixing since the page no longer contains "Holomorphic". At the same time I made some small changes in wording --at http://www.lmfdb.org/L/degree2/CuspForm/ the page starts "This is the browse of the L-functions associated to..." -- the first sentence is now a subheading.