### PR TITLE
Display of coefficient fields fixed

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -80,6 +80,9 @@ table.td.center {text-align : center;}
     {% endfor %}
   </tbody>
 </table>
+
+{% if space.dimension > orbits|length %} #this checks if there are forms which are not rational
+
 <p>The {{ KNOWL('mf.elliptic.coefficient_field',title='coefficient fields')}} are: </p>
 <table>
   <thead>
@@ -104,6 +107,7 @@ table.td.center {text-align : center;}
     {% endfor %}
   </tbody>
 </table>
+{% endif %}
 {% endif %}
 {% if space.character.order > 2%}
 


### PR DESCRIPTION
this fixes the display of Hecke eigenvalue fields if all the forms are rational

check it on:
http://localhost:37777/ModularForm/GL2/Q/holomorphic/33/8/1/
http://localhost:37777/ModularForm/GL2/Q/holomorphic/37/2/1/