### PR TITLE
fix #672: pass group argument

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -59,8 +59,10 @@ def browse_web_modform_spaces_in_ranges(**kwds):
 
     """
     emf_logger.debug("request.args={0}".format(request.args))
-    level=request.args['level']; weight=request.args['weight']
-    return _browse_web_modform_spaces_in_ranges(level=level,weight=weight)
+    level=request.args['level']
+    weight=request.args['weight']
+    group=request.args['group']
+    return _browse_web_modform_spaces_in_ranges(level=level,weight=weight,group=group)
 
 
 @emf.route("/", methods=met)
@@ -69,17 +71,17 @@ def browse_web_modform_spaces_in_ranges(**kwds):
 @emf.route("/<int:level>/<int:weight>/<int:character>/", methods=met)
 @emf.route("/<int:level>/<int:weight>/<int:character>/<label>", methods=met)
 @emf.route("/<int:level>/<int:weight>/<int:character>/<label>/", methods=met)
-def render_elliptic_modular_forms(level=0, weight=0, character=None, label='', **kwds):
+def render_elliptic_modular_forms(level=0, weight=0, character=None, group=0, label='', **kwds):
     r"""
     Default input of same type as required. Note that for holomorphic modular forms: level=0 or weight=0 are non-existent.
     """
     emf_logger.debug(
-        "In render: level={0},weight={1},character={2},label={3}".format(level, weight, character, label))
+        "In render: level={0},weight={1},character={2},group={3},label={4}".format(level, weight, character, group, label))
     emf_logger.debug("args={0}".format(request.args))
     emf_logger.debug("args={0}".format(request.form))
     emf_logger.debug("met={0}".format(request.method))
     keys = ['download', 'jump_to']
-    info = get_args(request, level, weight, character, label, keys=keys)
+    info = get_args(request, level, weight, character, group, label, keys=keys)
     level = info['level']
     weight = info['weight']
     character = info['character']
@@ -88,10 +90,12 @@ def render_elliptic_modular_forms(level=0, weight=0, character=None, label='', *
     emf_logger.debug("level=%s, %s" % (level, type(level)))
     emf_logger.debug("label=%s, %s" % (label, type(label)))
     emf_logger.debug("wt=%s, %s" % (weight, type(weight)))
-    emf_logger.debug("character=%s, %s" % (character, type(character)))
     group = info.get('group',None)
+    emf_logger.debug("group=%s, %s" % (group, type(group)))
     if group == 0:
         character = 1
+        info['character'] = 1
+    emf_logger.debug("character=%s, %s" % (character, type(character)))
     if 'download' in info:
         return get_downloads(**info)
     emf_logger.debug("info=%s" % info)
@@ -194,7 +198,7 @@ def redirect_false_route(test=None):
     return redirect(url_for("emf.render_elliptic_modular_forms",**args), code=301)
     # return render_elliptic_modular_form_navigation_wp(**info)
 
-def get_args(request, level=0, weight=0, character=-1, label='', keys=[]):
+def get_args(request, level=0, weight=0, character=-1, group=2, label='', keys=[]):
     r"""
     Use default input of the same type as desired output.
     """
@@ -207,6 +211,9 @@ def get_args(request, level=0, weight=0, character=-1, label='', keys=[]):
     info['level'] = my_get(dd, 'level', level, int)
     info['weight'] = my_get(dd, 'weight', weight, int)
     info['character'] = my_get(dd, 'character', character, int)
+    emf_logger.debug("group={0}".format(group))
+    info['group'] = my_get(dd, 'group', group, int)
+    emf_logger.debug("info[group]={0}".format(info['group']))
     info['label'] = my_get(dd, 'label', label, str)
     for key in keys:
         if key in dd:

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_main.py
@@ -93,8 +93,11 @@ def render_elliptic_modular_forms(level=0, weight=0, character=None, group=0, la
     group = info.get('group',None)
     emf_logger.debug("group=%s, %s" % (group, type(group)))
     if group == 0:
-        character = 1
-        info['character'] = 1
+        if character == -1 or character == None:
+            character = 1
+            info['character'] = 1
+        else:
+            group = 1 #or trigger an error?
     emf_logger.debug("character=%s, %s" % (character, type(character)))
     if 'download' in info:
         return get_downloads(**info)

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_navigation.py
@@ -114,6 +114,9 @@ def render_elliptic_modular_form_navigation_wp1(**args):
     emf_logger.debug("render_c_m_f_n_wp info={0}".format(info))
     level = my_get(info, 'level', 0, int)
     weight = my_get(info, 'weight', 0, int)
+    group = my_get(info, 'group', 1, int)
+    if group == int(0):
+      pass
     character = my_get(info, 'character', 1, int)
     label = info.get('label', '')
     #disp = ClassicalMFDisplay('modularforms2')
@@ -122,6 +125,7 @@ def render_elliptic_modular_form_navigation_wp1(**args):
     emf_logger.debug("label=%s, %s" % (label, type(label)))
     emf_logger.debug("wt=%s, %s" % (weight, type(weight)))
     emf_logger.debug("character=%s, %s" % (character, type(character)))
+    emf_logger.debug("group=%s, %s" % (group, type(group)))
     if('plot' in info and level is not None):
         return render_fd_plot(level, info)
     is_set = dict()
@@ -170,9 +174,11 @@ def render_elliptic_modular_form_navigation_wp1(**args):
     else:
         info['grouptype'] = 1; info['groupother'] = 0
     emf_logger.debug("level:{0},level_range={1}".format(level,limits_level))
-    emf_logger.debug("weight:{0},weight_range={1}".format(weight,limits_weight))    
+    emf_logger.debug("weight:{0},weight_range={1}".format(weight,limits_weight))
+
     if limits_weight[0] == limits_weight[1] and limits_level[0] == limits_level[1]:
-        return redirect(url_for("emf.render_elliptic_modular_forms", level=limits_level[0],weight=limits_weight[0]), code=301)
+        return redirect(url_for("emf.render_elliptic_modular_forms",
+          level=limits_level[0],weight=limits_weight[0],group=group), code=301)
     info['show_switch'] = True
     db = getDBConnection()['modularforms2']['webmodformspace_dimension']
     table = {}
@@ -284,10 +290,12 @@ def render_elliptic_modular_form_navigation_wp(**args):
         info['grouptype'] = 0; info['groupother'] = 1
     else:
         info['grouptype'] = 1; info['groupother'] = 0
+    emf_logger.debug("group=%s, %s" % (group, type(group)))
     emf_logger.debug("level:{0},level_range={1}".format(level,limits_level))
     emf_logger.debug("weight:{0},weight_range={1}".format(weight,limits_weight))    
     if limits_weight[0] == limits_weight[1] and limits_level[0] == limits_level[1]:
-        return redirect(url_for("emf.render_elliptic_modular_forms", level=limits_level[0],weight=limits_weight[0]), code=301)
+        return redirect(url_for("emf.render_elliptic_modular_forms",
+          level=limits_level[0],weight=limits_weight[0],group=group), code=301)
     info['show_switch'] = True
     db = getDBConnection()['modularforms2']['dimension_table']
     s = {'level':{"$lt":int(limits_level[1]+1),"$gt":int(limits_level[0]-1)},

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_browse_spaces.html
@@ -187,10 +187,12 @@ table.ntdata thead th.spaceleft {
                   {% set in_db = table[N][k]['in_db'] %}
                   {% if in_db == 1 %}
                      {% if info.grouptype == 0 %}
-                       {% set url = url_for('emf.render_elliptic_modular_forms',level=N,weight=k,character=1)
+                       {% set url =
+                       url_for('emf.render_elliptic_modular_forms',level=N,weight=k,character=1,group=0)
                        %}
                     {% else %}
-                       {% set url = url_for('emf.render_elliptic_modular_forms',level=N,weight=k)
+                       {% set url =
+                       url_for('emf.render_elliptic_modular_forms',level=N,weight=k,group=1)
                          %}
                     {% endif %}
                  <a href="{{url}}">{{dim}}</a>


### PR DESCRIPTION
Fix #672.
Example: in the main page of holomorphic modular forms, fill in browse form with (4,10) for Gamma_0. This used to redirect to a Gamma_1 page.

Please test that the Gamma_0/Gamma_1 behaviour is still correct in other cases (combinations of clicking and browse box), since the changes in the code may affect any of these.