### PR TITLE
Fixes for Issue #690

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_download_utils.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/backend/emf_download_utils.py
@@ -20,8 +20,8 @@ def get_coefficients(info):
     level = my_get(info, 'level', -1, int)
     weight = my_get(info, 'weight', -1, int)
     character = my_get(info, 'character', '', str)  # int(info.get('weight',0))
-    number=my_get(info,'number',0,int)
-    label=my_get(info,'label','',str)    
+    number=my_get(info,'number',0,int) + 1
+    label=my_get(info,'label','',str)
     emf_logger.debug("info={0}".format(info))
     if character == '':
         character = 0
@@ -38,9 +38,9 @@ def get_coefficients(info):
     else:
         ending = "txt"
     info['filename'] = str(weight) + '-' + str(
-        level) + '-' + str(character) + '-' + label + 'coefficients-0to' + info['number'] + "."+ending
+        level) + '-' + str(character) + '-' + label + 'coefficients-0to' + str(number) + "."+ending
     # return send_file(info['tempfile'], as_attachment=True, attachment_filename=info['filename'])
-    
+
     strIO = StringIO.StringIO()
     strIO.write(s)
     strIO.seek(0)
@@ -114,9 +114,9 @@ def print_list_of_coefficients(info):
     if not WMFS:
         return ""
     if('number' in info):
-        number = int(info['number'])
+        number = int(info['number']) + 1
     else:
-        number = max(WMFS.sturm_bound() + 1, 20)
+        number = max(WMFS.sturm_bound + 1, 20)
     FS = list()
     f  = WMFS.hecke_orbits.get(label)
     if f is not None:
@@ -165,34 +165,39 @@ def print_coefficients_for_one_form(F, number, fmt="q_expansion",bitprec=53):
     #if number > max_cn:
     #    number = max_cn
     ## TODO: add check that we have sufficiently many coefficients!
+    deg = F.coefficient_field.absolute_degree() # OK for QQ too
+    if deg > 1:
+        pol = F.coefficient_field.relative_polynomial()
+    #emf_logger.debug("deg={0}".format(deg))
     if fmt == "q_expansion":
+        if deg > 1:
+            s += "\n## coefficient field : "+str(pol)+"=0"
+        else:
+            s += "## coefficient field : Rational Field"
+        s += "\n\n"
         s += str(F.q_expansion.truncate_powerseries(number))
     if fmt == "coefficients":
         qe = F.coefficients(range(number))
         #emf_logger.debug("F={0}".format(F))
         #deg=0 [emf_download_utils.py:147
-        deg = F.coefficient_field.degree()
-        #emf_logger.debug("deg={0}".format(deg))        
         if deg > 1:
-            pol = F.coefficient_field.polynomial()
-            s += "## coefficient field : "+str(pol)+"=0"
-            s += "\n"
+            s += "\n## coefficient field : "+str(pol)+"=0"
         else:
-            s += "## coefficient field : Rational Field"
-            s += "\n"            
+            s += "\n## coefficient field : Rational Field"
+        s += "\n\n"
         for n in range(len(qe)):
             c=qe[n]
             s += "{n} \t {c} \n".format(n=n,c=c)
         emf_logger.debug("qe={0}".format(qe))
-         
+
     if fmt == "embeddings":
         #embeddings = F.q_expansion_embeddings(number,bitprec=bitprec,format='numeric')
         deg = F.coefficient_field.degree()
         for j in range(deg):
             if deg > 1:
-                s+="# Embedding nr. {j} \n".format(j=j)            
+                s+="# Embedding nr. {j} \n".format(j=j)
             for n in range(number):
                 s += str(n) + "\t" + str(F.coefficient_embedding(n,j)) + "\n"
-        
+
     emf_logger.debug("s={0}".format(s))
     return s

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_newform.html
@@ -24,6 +24,7 @@
 	<div class="emptyspace"><br>
         </div>
         <button id="morebutton">Show more coefficients</button>
+        (To download coefficients,  see below.)
     </form>
 </div>
 </div>
@@ -194,43 +195,56 @@ that preserve the character are shown in the table below.
   {% endif %}
 <h2>Download {{KNOWL('mf.elliptic.fouriercoefficients',title='Fourier coefficients')}} </h2>
 
-The database contains the coefficients of \(q^n\) for \(n\le {{ max_cn - 1 }} \).
+The database contains the coefficients of \(q^n\) for \(0 \le n\le {{ max_cn - 1 }} \).
 <form name="get_coefficients" method="post"  action="{{url_for('.get_downloads',level=level,weight=weight,character=character,label=label)}}">
 <input type="hidden" name="download" value="coefficients"/>
 <input type="hidden" name="max_num" value="{{max_cn}}"/>
-  Choose format to download:
-  <ul>
-    <li> 
+
+<table>
+<tr><td rowspan=4>Choose format to download:</td>
+<td>
       <label><input type=radio name="format" checked
     value="q_expansion" onclick="return selectCFormat(event)">
-    q-expansion (text format)</label>
-    </li>
-    <li> 
+    text file of the q-expansion</label>
+</td>
+</tr>
+<tr>
+<td>
       <label><input type=radio name="format" checked
     value="coefficients" onclick="return selectCFormat(event)">
-    algebraic coefficients (text format)</label>
-    </li>
-    <li>
+    text file of the algebraic coefficients in a table</label>
+</td>
+</tr>
+<tr>
+<td>
       <label><input type=radio name="format" value="embeddings"
     onclick="return selectCFormat(event)">
-    complex embeddings (double 
-    precision, text format) </label>
+    text file of the complex coefficients in double precision</label>
       <!-- with <input type="text" size="10" name="bitprec" value="15"> digits precision.     -->
-    </li>
-    <li>
+</td>
+</tr>
+<tr>
+<td>
     <label><input type=radio name="format" value="sage"
     onclick="return selectCFormat(event)">
-    sage objects (algebraic, sage pickle) </label>
-    </li>
-  </ul>
-  Number of coefficients to download <input type="text" size="10"
-  name="number" required value="10"/>
+    sage object (representing a list of algebraic numbers) </label>
+</td>
+</tr>
+<tr>
+<td>  Download coefficients of \(q^n\) for \(0\le n\le \) </td>
+<td>
+  <input type="text" size="10" name="number" example = 99> (maximum {{ max_cn - 1 }})
   <br><span class=" " id="num_error"></span>
+</td>
+</tr>
+</table>
+
   <div>
-    <input type="submit" name="Submit" value="Get coefficients">
+    <input type="submit" name="Submit" value="Download">
   </div>
   </form>
-  
+
+{#
 <h2>Download this newform as {{KNOWL('sage',title='Sage')}} Object</h2>
 <form name="download_object_form" method="post"  action="{{url_for('.render_elliptic_modular_forms')}}">
   <input type="hidden" name="download" value="object">
@@ -242,9 +256,8 @@ The database contains the coefficients of \(q^n\) for \(n\le {{ max_cn - 1 }} \)
 </form>
 <div class="formexample"> 
 <!--  Note: In order to use this data file you currently need to download
-  and import the entire lmfdb from:  -->
-<a href="https://github.com/LMFDB/lmfdb">lmfdb at github</a>. 
-{#
+  and import the entire lmfdb from:  
+<a href="https://github.com/LMFDB/lmfdb">lmfdb at github</a>. -->
 <form name="download_file" method="post"  action="{{url_for('.render_elliptic_modular_forms')}}">
   Note: In order to use this data file you currently need to download
   <input type="hidden" name="download" value="file">

--- a/lmfdb/test_lfunction.py
+++ b/lmfdb/test_lfunction.py
@@ -75,10 +75,6 @@ class LfunctionTest(LmfdbTest):
         L = self.tc.get('/L/EllipticCurve/Q/56.a/?download=lcalcfile')
         assert 'lcalc' in L.data
 
-    def test_Llcalcurl(self):
-        L = self.tc.get('/L/Lcalcurl/?url=http://www.math.chalmers.se/~sj/pub/gl3Maass/Data/sl3Maass1.txt')
-        assert 'Graph' in L.data
-
     def test_Lmain(self):
         L = self.tc.get('/L/')
         assert 'Riemann' in L.data


### PR DESCRIPTION
As well as what was asked for there is some reformatting of the Download part of the page, and some bug-fixing for the content of the download file itself.  We also commented out the part which offers to download as a Sage object since that can only be loaded into Sage+lmfdb so can be put off for later.

To test all these you need to look at (1) rational coefficients, e.g. 11/2/1/a/, (2) algebraic coefficients with no character, e.g. 23/12/1/a/, and (3) algebraic coefficients with character (so the coefficient field is relative), e.g. 5/9/2/a/
