### PR TITLE
fix #698: make dimension not clickable when Hecke orbits are not stored

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/emf_render_web_modform_space_gamma1.py
@@ -101,8 +101,15 @@ def set_info_for_gamma1(level,weight,weight2=None):
                 table['maxGalCount']=len(orbit)
             table['cells'][xi]={}
             d = r.get('d_newf',"n/a")
-            url = url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xi)
+            indb = r.get('in_wdb',0)
+            if d == 0:
+                indb = 1
+            if indb:
+                url = url_for('emf.render_elliptic_modular_forms', level=level, weight=k, character=xi)
+            else:
+                url = ''
             table['cells'][xi][k] ={'N': level, 'k': k, 'chi': xi, 'url': url, 'dim': d}
     table['galois_orbits_reps_numbers']=table['galois_orbits_reps'].keys()
     table['galois_orbits_reps_numbers'].sort()
+    #emf_logger.debug("Table:{0}".format(table))
     return table

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_render_web_modform_space_gamma1.html
@@ -144,6 +144,10 @@ with specified {{ KNOWL('character.dirichlet',title='character') }} for \( \Gamm
     </tr>
   </tbody>
 </table>
+    <small>"n/a" means that there is no information about this space in our
+      database. The dimension is clickable whenever the Hecke orbits are 
+    stored for that space.</small>
+  <br/>
 
 {% if showGaloisOrbits %}
 
@@ -158,7 +162,8 @@ The complete Galois orbits of characters are shown in the table below.
   <thead>
     <tr class="space">
       <th class="spaceleft">Representative</th>
-      <th class="weight" colspan="{{table.maxGalCount}}">Galois orbit</th>
+      <th class="weight" colspan="{{table.maxGalCount}}">Galois orbit of
+        characters</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Example:
/ModularForm/GL2/Q/holomorphic/17/4/
This is currently the only test case because all spaces pretend to have their Hecke orbits in the database, see issue #700. Here the last database entry was modified by hand.