### PR TITLE
Align q-exp to top

### DIFF
--- a/Pretty1.sage
+++ b/Pretty1.sage
@@ -14,7 +14,7 @@ def Modf_changevar(f,NF,Bfacto=10^6):
  QQx.<x>=QQ[]
  P=f.absolute_polynomial
  # If f is rational, nothing to do :)
- if f.is_rational:
+ if P.degree()==1:
   return [f.eigenvalues.v,u'1.1.1.1']
  # Is the coefficient field already identified ?
  Klabel=f.coefficient_field.lmfdb_label
@@ -76,6 +76,7 @@ def Modf_changevar(f,NF,Bfacto=10^6):
 
  if Klabel=='':
   # Field not found, so we reduce the initial polynomial as we can
+  print "Not found"
   [Q,iso]=gp.polredbest(P,1)
   Q=ZZx(str(Q))
   pkQ=gp.nfinit([Q,Bfacto])

--- a/Pretty1.sage
+++ b/Pretty1.sage
@@ -78,30 +78,35 @@ def Modf_changevar(f,NF,Bfacto=10^6):
   # Field not found, so we reduce the initial polynomial as we can
   [Q,iso]=gp.polredbest(P,1)
   Q=ZZx(str(Q))
-  pKQ=gp.nfinit([Q,Bfacto])
+  pkQ=gp.nfinit([Q,Bfacto])
   iso=QQx(str(gp.lift(iso)))
 
  # Now we have the model we want for the absolute field.
  # We now want the explicit embedding of the cyclotomic field, the relative polynomial for this new field, and the relative version of the isomorphism
  E=f.eigenvalues.E
+ v=f.eigenvalues.v
+ print Q
+ print iso
+ KQ.<a>=NumberField(Q)
  Kcyc=E.base_ring().base_ring()
  if Kcyc.degree()>1:
-  polcyc=Kcyc.defining_polynomial
+  polcyc=Kcyc.defining_polynomial()
   relP=E.base_ring().defining_polynomial()
-  emb=gp.nfisincl(polcyc,pKQ)[1]
-  Cycx.<x>=Cyc[]
-  Cycxy.<y>=Cycx[]
-  relQ=relP(y).resultant(y-iso(x))
-  pKcyc=gp.nfinit(QQy(polcyc))
-  relQ=TODO
-  R=Cyc.extension(TODO)
-  relIso=R(iso)
-  #TODO
-  return TODO
+  print relP
+  emb=QQx(str(gp.nfisincl(polcyc,pkQ)[1]))(a)
+  print emb
+  Krel.<a>=Kcyc.extension(relP)
+  osi=gp.lift(gp.modreverse(gp.Mod(iso,Q)))
+  osi=QQx(str(osi))
+  relQ=osi(a).charpoly()
+  print relQ
+  R.<a>=Kcyc.extension(relQ)
+  relIso=iso(a)
+  newv=[l.lift()(relIso) for l in v]
+  return [newv,E.apply_map(lambda x:x[0]).base_extend(R),Q,emb,Klabel]
 
  # Finally, apply isomorphism
  KQ.<a>=NumberField(Q)
  iso=KQ(iso)
- v=f.eigenvalues.v
  newv=[l.lift()(iso) for l in v]
  return [newv,Klabel]

--- a/Pretty1.sage
+++ b/Pretty1.sage
@@ -7,7 +7,7 @@ from lmfdb.number_fields.number_field import make_disc_key
 def Modf_changevar(f,NF,Bfacto=10^6):
  ######
  # Usage : f a hecke_orbit, NF=lmfdb.base.getDBConnection()['numberfields']['fields']
- # Returns : [v2,label], where v2 is v expressed on a nice model of the coeff field, and label is the lmfdb label of the field (or '' if not in the database)
+ # Returns : [v2,E2,Q,emb,label], where v2 and E2 are v and E expressed on a nice model of the coeff field, Q is the absolute defining polynomial of this model, emb is the embeddding of the generator of the cycltomic subfield (for Gamma1), and label is the lmfdb label of the field (or '' if not in the database)
  ######
  
  ZZx.<x>=ZZ[]
@@ -86,15 +86,15 @@ def Modf_changevar(f,NF,Bfacto=10^6):
  E=f.eigenvalues.E
  v=f.eigenvalues.v
  print Q
- print iso
+ print "iso",iso
  KQ.<a>=NumberField(Q)
- Kcyc=E.base_ring().base_ring()
+ Kcyc=v[0].parent().base_ring()
  if Kcyc.degree()>1:
   polcyc=Kcyc.defining_polynomial()
-  relP=E.base_ring().defining_polynomial()
+  relP=v[0].parent().defining_polynomial()
   print relP
   emb=QQx(str(gp.nfisincl(polcyc,pkQ)[1]))(a)
-  print emb
+  print "emb",emb
   Krel.<a>=Kcyc.extension(relP)
   osi=gp.lift(gp.modreverse(gp.Mod(iso,Q)))
   osi=QQx(str(osi))
@@ -103,10 +103,12 @@ def Modf_changevar(f,NF,Bfacto=10^6):
   R.<a>=Kcyc.extension(relQ)
   relIso=iso(a)
   newv=[l.lift()(relIso) for l in v]
-  return [newv,E.apply_map(lambda x:x[0]).base_extend(R),Q,emb,Klabel]
+  if E.base_ring() != Kcyc:
+   E=E.apply_map(lambda x:x[0])
+  return [newv,E,Q,emb,Klabel]
 
  # Finally, apply isomorphism
  KQ.<a>=NumberField(Q)
  iso=KQ(iso)
  newv=[l.lift()(iso) for l in v]
- return [newv,Klabel]
+ return [newv,E,Q,QQx.gen(),Klabel]

--- a/Pretty1.sage
+++ b/Pretty1.sage
@@ -1,0 +1,107 @@
+import pymongo
+import lmfdb
+from lmfdb.modular_forms.elliptic_modular_forms import *
+from lmfdb.number_fields.number_field import make_disc_key
+
+
+def Modf_changevar(f,NF,Bfacto=10^6):
+ ######
+ # Usage : f a hecke_orbit, NF=lmfdb.base.getDBConnection()['numberfields']['fields']
+ # Returns : [v2,label], where v2 is v expressed on a nice model of the coeff field, and label is the lmfdb label of the field (or '' if not in the database)
+ ######
+ 
+ ZZx.<x>=ZZ[]
+ QQx.<x>=QQ[]
+ P=f.absolute_polynomial
+ # If f is rational, nothing to do :)
+ if f.is_rational:
+  return [f.eigenvalues.v,u'1.1.1.1']
+ # Is the coefficient field already identified ?
+ Klabel=f.coefficient_field.lmfdb_label
+ if Klabel:
+  # It is, let us make the isomorphism explicit
+  K=NF.find_one({'label':Klabel})
+  Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+  # Compute max order in gp
+  pkQ=gp.nfinit([Q,[ZZ(p) for p in K['ramps']]])
+  iso=QQx(str(gp.nfisisom(pkQ,P)[1]))
+ else:
+  # It is not, let us see if it exists in the DB
+  plist=[p for p in range(200) if is_prime(p)]
+  query={}
+  # Lazy order
+  pKP=gp.nfinit([P,Bfacto])
+  # Sign
+  [r1,r2]=pKP[2]
+  query['signature']=str(r1)+','+str(r2)
+  DpKP=pKP[3]
+  # Is the lazy order maximal ?
+  if len(gp.nfcertify(pKP)):
+   # The lazy order is not maximal
+   ur=[]
+   ram=[]
+   # Primes<200 known to be unramified
+   for p in plist:
+    if Mod(DpKP,p):
+     ur.append(str(p))
+   # Lazy factorisation of the disc of the lazy order
+   faD=gp.factor(DpKP,Bfacto)
+   faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
+   # Primes known to be ramified
+   for s in faD:
+    p=s.split(',')[0].replace(' ','')
+    if ZZ(p)<Bfacto:
+     ram.append(p)
+   query['$nor'] = [{'ramps': x} for x in ur]
+   query['ramps'] = {'$all': ram}
+  else:
+   # The lazy order is maximal :)
+   # Query on disc
+   s,D=make_disc_key(ZZ(DpKP))
+   query['disc_sign']=s
+   query['disc_abs_key']=D
+  LK=NF.find(query)
+  Klabel=''
+  for K in LK:
+   # Found a candidate in the nf DB, here is its defining polynomial
+   Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+   # Compute max order in gp
+   pkQ=gp.nfinit([Q,[ZZ(p) for p in K['ramps']]])
+   # Check for isomorphism
+   iso=gp.nfisisom(pkQ,P)
+   if iso:
+    iso=QQx(str(iso[1]))
+    Klabel=K['label']
+    break
+
+ if Klabel=='':
+  # Field not found, so we reduce the initial polynomial as we can
+  [Q,iso]=gp.polredbest(P,1)
+  Q=ZZx(str(Q))
+  pKQ=gp.nfinit([Q,Bfacto])
+  iso=QQx(str(gp.lift(iso)))
+
+ # Now we have the model we want for the absolute field.
+ # We now want the explicit embedding of the cyclotomic field, the relative polynomial for this new field, and the relative version of the isomorphism
+ E=f.eigenvalues.E
+ Kcyc=E.base_ring().base_ring()
+ if Kcyc.degree()>1:
+  polcyc=Kcyc.defining_polynomial
+  relP=E.base_ring().defining_polynomial()
+  emb=gp.nfisincl(polcyc,pKQ)[1]
+  Cycx.<x>=Cyc[]
+  Cycxy.<y>=Cycx[]
+  relQ=relP(y).resultant(y-iso(x))
+  pKcyc=gp.nfinit(QQy(polcyc))
+  relQ=TODO
+  R=Cyc.extension(TODO)
+  relIso=R(iso)
+  #TODO
+  return TODO
+
+ # Finally, apply isomorphism
+ KQ.<a>=NumberField(Q)
+ iso=KQ(iso)
+ v=f.eigenvalues.v
+ newv=[l.lift()(iso) for l in v]
+ return [newv,Klabel]

--- a/Pretty2.sage
+++ b/Pretty2.sage
@@ -1,0 +1,90 @@
+import pymongo
+import lmfdb
+from lmfdb.modular_forms.elliptic_modular_forms import *
+from lmfdb.number_fields.number_field import make_disc_key
+
+
+def Modf_changevar(f,NF,Bfacto=10^6):
+ ######
+ # Usage : f a hecke_orbit, NF=lmfdb.base.getDBConnection()['numberfields']['fields']
+ # Returns : [v2,label], where v2 is v expressed on a nice model of the coeff field, and label is the lmfdb label of the field (or '' if not in the database)
+ ######
+ 
+ ZZx.<x>=ZZ[]
+ QQx.<x>=QQ[]
+ P=f.absolute_polynomial
+ # If f is rational, nothing to do :)
+ if f.is_rational:
+  return [f.eigenvalues.v,u'1.1.1.1']
+ # Is the coefficient field already identified ?
+ Klabel=f.coefficient_field.lmfdb_label
+ if Klabel:
+  # It is, let us make the isomorphism explicit
+  K=NF.find_one({'label':Klabel})
+  Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+  # Compute max order in gp
+  maxram=max([ZZ(a) for a in K['ramps']])
+  pkQ=gp.nfinit([Q,maxram+1])
+  iso=QQx(str(gp.nfisisom(pkQ,P)[1]))
+ else:
+  # It is not, let us see if it exists in the DB
+  plist=[p for p in range(200) if is_prime(p)]
+  query={}
+  # Lazy order
+  pKP=gp.nfinit([P,Bfacto])
+  # Sign
+  [r1,r2]=pKP[2]
+  query['signature']=str(r1)+','+str(r2)
+  DpKP=pKP[3]
+  # Is the lazy order maximal ?
+  if len(gp.nfcertify(pKP)):
+   # The lazy order is not maximal
+   ur=[]
+   ram=[]
+   # Primes<200 known to be unramified
+   for p in plist:
+    if Mod(DpKP,p):
+     ur.append(str(p))
+   # Lazy factorisation of the disc of the lazy order
+   faD=gp.factor(DpKP,Bfacto)
+   faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
+   # Primes known to be ramified
+   for s in faD:
+    p=s.split(',')[0].replace(' ','')
+    if ZZ(p)<Bfacto:
+     ram.append(p)
+   query['$nor'] = [{'ramps': x} for x in ur]
+   query['ramps'] = {'$all': ram}
+  else:
+   # The lazy order is maximal :)
+   # Query on disc
+   s,D=make_disc_key(ZZ(DpKP))
+   query['disc_sign']=s
+   query['disc_abs_key']=D
+  LK=NF.find(query)
+  Klabel=''
+  for K in LK:
+   # Found a candidate in the nf DB, here is its defining polynomial
+   Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+   # Compute max order in gp
+   maxram=max([ZZ(a) for a in K['ramps']])
+   pkQ=gp.nfinit([Q,maxram+1])
+   # Check for isomorphism
+   iso=gp.nfisisom(pkQ,P)
+   if iso:
+    iso=QQx(str(iso[1]))
+    Klabel=K['label']
+    break
+
+ if Klabel=='':
+  # Field not found, so we reduce the initial polynomial as we can
+  [Q,iso]=gp.polredbest(P,1)
+  Q=ZZx(str(Q))
+  iso=QQx(str(gp.lift(iso)))
+
+ # Finally, apply isomorphism
+ KQ.<a>=NumberField(Q)
+ iso=KQ(iso)
+ v=f.eigenvalues.v
+ newv=[l.lift()(iso) for l in v]
+ return [newv,Klabel]

--- a/PrettyCoeffs.sage
+++ b/PrettyCoeffs.sage
@@ -1,0 +1,79 @@
+import pymongo
+import lmfdb
+from lmfdb.modular_forms.elliptic_modular_forms import *
+from lmfdb.number_fields.number_field import make_disc_key
+
+C=lmfdb.base.getDBConnection()
+NF=C['numberfields']['fields']
+
+##from lmfdb.WebNumberField import decodedisc
+
+M=WebModFormSpace(106,4,1)
+f=M.hecke_orbits['c']
+
+plist=[p for p in range(200) if is_prime(p)]
+
+query={}
+P=f.absolute_polynomial
+print P
+#n=P.degree()
+#r1=len(P.real_roots())
+#r2=(n-r1)/2
+pKP=gp.nfinit([P,10^6])
+[r1,r2]=pKP[2]
+query['signature']=str(r1)+','+str(r2)
+DpKP=pKP[3]
+if len(gp.nfcertify(pKP)):
+ print "Exact disc unknown"
+ ur=[]
+ ram=[]
+ for p in plist:
+  if Mod(DpKP,p):
+   ur.append(str(p))
+ faD=gp.factor(DpKP,10^6)
+ faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
+ for s in faD:
+  p=s.split(',')[0].replace(' ','')
+  if ZZ(p)<10^6:
+   ram.append(p)
+ query['$nor'] = [{'ramps': x} for x in ur]
+ query['ramps'] = {'$all': ram}
+else:
+ print "Exact disc known"
+ s,D=make_disc_key(ZZ(DpKP))
+ query['disc_sign']=s
+ query['disc_abs_key']=D
+
+LK=NF.find(query)
+#print len(list(LK))
+
+ZZx=P.parent()
+QQx=ZZx.base_extend(QQ)
+
+K0=0
+Klabel=''
+for K in LK:
+ Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+ print Q
+ maxram=max([ZZ(a) for a in K['ramps']])
+ pkQ=gp.nfinit([Q,maxram+1])
+ iso=gp.nfisisom(pkQ,P)
+ if iso:
+  iso=QQx(str(iso[1]))
+  K0=K
+  Klabel=K0['label']
+  print "Found "+Klabel
+  break
+
+if K0==0:
+ # Field not found
+ [Q,iso]=gp.polredbest(P,1)
+ Q=ZZx(str(Q))
+ iso=QQx(str(gp.lift(iso)))
+
+KQ.<a>=NumberField(Q)
+iso=KQ(iso)
+qprec=f.prec+1
+newcoeffs=[0 for i in range(qprec)]
+for i in range(1,qprec):
+ newcoeffs[i]=f.coefficient(i).lift()(iso)

--- a/PrettyCoeffs.sage
+++ b/PrettyCoeffs.sage
@@ -3,13 +3,15 @@ import lmfdb
 from lmfdb.modular_forms.elliptic_modular_forms import *
 from lmfdb.number_fields.number_field import make_disc_key
 
+Bfacto=10^6
+
 C=lmfdb.base.getDBConnection()
 NF=C['numberfields']['fields']
 
 ##from lmfdb.WebNumberField import decodedisc
 
 M=WebModFormSpace(106,4,1)
-f=M.hecke_orbits['c']
+f=M.hecke_orbits['b']
 
 plist=[p for p in range(200) if is_prime(p)]
 
@@ -19,7 +21,7 @@ print P
 #n=P.degree()
 #r1=len(P.real_roots())
 #r2=(n-r1)/2
-pKP=gp.nfinit([P,10^6])
+pKP=gp.nfinit([P,Bfacto])
 [r1,r2]=pKP[2]
 query['signature']=str(r1)+','+str(r2)
 DpKP=pKP[3]
@@ -30,11 +32,11 @@ if len(gp.nfcertify(pKP)):
  for p in plist:
   if Mod(DpKP,p):
    ur.append(str(p))
- faD=gp.factor(DpKP,10^6)
+ faD=gp.factor(DpKP,Bfacto)
  faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
  for s in faD:
   p=s.split(',')[0].replace(' ','')
-  if ZZ(p)<10^6:
+  if ZZ(p)<Bfacto:
    ram.append(p)
  query['$nor'] = [{'ramps': x} for x in ur]
  query['ramps'] = {'$all': ram}
@@ -73,7 +75,9 @@ if K0==0:
 
 KQ.<a>=NumberField(Q)
 iso=KQ(iso)
-qprec=f.prec+1
+#pKQ=gp.nfinit([Q,Bfacto])
+qprec=f.prec
 newcoeffs=[0 for i in range(qprec)]
 for i in range(1,qprec):
  newcoeffs[i]=f.coefficient(i).lift()(iso)
+ #newcoeffs[i]=gp.nfalgtobasis(pKQ,f.coefficient(i).lift()(iso).lift())

--- a/PrettyCoeffs.sage
+++ b/PrettyCoeffs.sage
@@ -3,81 +3,88 @@ import lmfdb
 from lmfdb.modular_forms.elliptic_modular_forms import *
 from lmfdb.number_fields.number_field import make_disc_key
 
-Bfacto=10^6
 
 C=lmfdb.base.getDBConnection()
 NF=C['numberfields']['fields']
 
-##from lmfdb.WebNumberField import decodedisc
-
 M=WebModFormSpace(106,4,1)
 f=M.hecke_orbits['b']
 
-plist=[p for p in range(200) if is_prime(p)]
 
-query={}
-P=f.absolute_polynomial
-print P
-#n=P.degree()
-#r1=len(P.real_roots())
-#r2=(n-r1)/2
-pKP=gp.nfinit([P,Bfacto])
-[r1,r2]=pKP[2]
-query['signature']=str(r1)+','+str(r2)
-DpKP=pKP[3]
-if len(gp.nfcertify(pKP)):
- print "Exact disc unknown"
- ur=[]
- ram=[]
- for p in plist:
-  if Mod(DpKP,p):
-   ur.append(str(p))
- faD=gp.factor(DpKP,Bfacto)
- faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
- for s in faD:
-  p=s.split(',')[0].replace(' ','')
-  if ZZ(p)<Bfacto:
-   ram.append(p)
- query['$nor'] = [{'ramps': x} for x in ur]
- query['ramps'] = {'$all': ram}
-else:
- print "Exact disc known"
- s,D=make_disc_key(ZZ(DpKP))
- query['disc_sign']=s
- query['disc_abs_key']=D
+def Modf_changevar(f,NF,Bfacto=10^6):
+ # Gather information of the coefficient field and try to find it in DB
+ plist=[p for p in range(200) if is_prime(p)]
+ query={}
+ P=f.absolute_polynomial
+ print P
+ ZZx=P.parent()
+ QQx=ZZx.base_extend(QQ)
+ # Lazy order
+ pKP=gp.nfinit([P,Bfacto])
+ # Sign
+ [r1,r2]=pKP[2]
+ query['signature']=str(r1)+','+str(r2)
+ DpKP=pKP[3]
+ # Is the lazy order maximal ?
+ if len(gp.nfcertify(pKP)):
+  # The lazy order is not maximal
+  print "Exact disc unknown"
+  ur=[]
+  ram=[]
+  # Primes<200 known to be unramified
+  for p in plist:
+   if Mod(DpKP,p):
+    ur.append(str(p))
+  # Lazy factorisation of the disc of the lazy order
+  faD=gp.factor(DpKP,Bfacto)
+  faD=str(faD).replace('[','').replace(']','').replace('Mat(','').replace(')','').split(';')
+  #Primes known to be ramified
+  for s in faD:
+   p=s.split(',')[0].replace(' ','')
+   if ZZ(p)<Bfacto:
+    ram.append(p)
+  query['$nor'] = [{'ramps': x} for x in ur]
+  query['ramps'] = {'$all': ram}
+ else:
+  # The lazy order is maximal :)
+  print "Exact disc known"
+  # Query on disc
+  s,D=make_disc_key(ZZ(DpKP))
+  query['disc_sign']=s
+  query['disc_abs_key']=D
 
-LK=NF.find(query)
-#print len(list(LK))
+ LK=NF.find(query)
 
-ZZx=P.parent()
-QQx=ZZx.base_extend(QQ)
+ K0=0
+ Klabel=''
+ for K in LK:
+  # Found a candidate in the nf DB, here is its defining polynomial
+  Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
+  print Q
+  # Compute max order in gp
+  maxram=max([ZZ(a) for a in K['ramps']])
+  pkQ=gp.nfinit([Q,maxram+1])
+  # Check for isomorphism
+  iso=gp.nfisisom(pkQ,P)
+  if iso:
+   iso=QQx(str(iso[1]))
+   K0=K
+   Klabel=K0['label']
+   print "Found "+Klabel
+   break
 
-K0=0
-Klabel=''
-for K in LK:
- Q=ZZx([ZZ(a) for a in K['coeffs'].split(',')])
- print Q
- maxram=max([ZZ(a) for a in K['ramps']])
- pkQ=gp.nfinit([Q,maxram+1])
- iso=gp.nfisisom(pkQ,P)
- if iso:
-  iso=QQx(str(iso[1]))
-  K0=K
-  Klabel=K0['label']
-  print "Found "+Klabel
-  break
+ if K0==0:
+  # Field not found, so we reduce the initial polynomial as we can
+  [Q,iso]=gp.polredbest(P,1)
+  Q=ZZx(str(Q))
+  iso=QQx(str(gp.lift(iso)))
 
-if K0==0:
- # Field not found
- [Q,iso]=gp.polredbest(P,1)
- Q=ZZx(str(Q))
- iso=QQx(str(gp.lift(iso)))
-
-KQ.<a>=NumberField(Q)
-iso=KQ(iso)
-#pKQ=gp.nfinit([Q,Bfacto])
-qprec=f.prec
-newcoeffs=[0 for i in range(qprec)]
-for i in range(1,qprec):
- newcoeffs[i]=f.coefficient(i).lift()(iso)
- #newcoeffs[i]=gp.nfalgtobasis(pKQ,f.coefficient(i).lift()(iso).lift())
+ # Apply isomorphism
+ KQ.<a>=NumberField(Q)
+ iso=KQ(iso)
+ v=f.eigenvalues.v
+ newv=[l.lift()(iso) for l in v]
+ #newcoeffs=[0 for i in range(qprec)]
+ #for i in range(1,qprec):
+  #newcoeffs[i]=f.coefficient(i).lift()(iso)
+ return [newv,Klabel]

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -67,10 +67,10 @@ table.td.center {text-align : center;}
     {% for label in orbits %}
        {% set f = space.hecke_orbits[label] %}
        <tr>
-      <td><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
+      <td valign="top"><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
       <td align="center" valign="top">
         {{ f.dimension }}</td>
-	<td align="center">
+	<td align="center" valign="top">
         {% if f.coefficient_field.lmfdb_label == '1.1.1.1'%}
             <a href="{{ f.coefficient_field.lmfdb_url }}">{{ f.coefficient_field.lmfdb_pretty }}</a></td>
         {% else %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -51,7 +51,7 @@ table.td.center {text-align : center;}
   Decomposition of {{new_name}} into {{ KNOWL('mf.elliptic.hecke-orbits',title='irreducible Hecke orbits')}}
 </h2>
 {% if  space.hecke_orbits=={} %}
-   Problem with Hecke orbits in the datbase!
+   Problem with Hecke orbits in the database!
 {% else %}
 <table>
   <thead>
@@ -68,7 +68,7 @@ table.td.center {text-align : center;}
        {% set f = space.hecke_orbits[label] %}
        <tr>
       <td><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
-      <td align="center">
+      <td align="center" valign="top">
         {{ f.dimension }}</td>
 	<td align="center">
         {% if f.coefficient_field.lmfdb_label == '1.1.1.1'%}


### PR DESCRIPTION
Fixes #710. On mf pages with very large q-exps, the name of the form, field of coeffs and dimension are now vertically aligned with the top of the q-exp (instead of the centre). Cf. 11/10/4 or 23/12/1 for instance.