### PR TITLE
Align to top of q-exps

### DIFF
--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -67,10 +67,10 @@ table.td.center {text-align : center;}
     {% for label in orbits %}
        {% set f = space.hecke_orbits[label] %}
        <tr>
-      <td><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
+      <td valign="top"><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
       <td align="center" valign="top">
         {{ f.dimension }}</td>
-	<td align="center">
+	<td align="center" valign="top">
         {% if f.coefficient_field.lmfdb_label == '1.1.1.1'%}
             <a href="{{ f.coefficient_field.lmfdb_url }}">{{ f.coefficient_field.lmfdb_pretty }}</a></td>
         {% else %}

--- a/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
+++ b/lmfdb/modular_forms/elliptic_modular_forms/views/templates/emf_web_modform_space.html
@@ -51,7 +51,7 @@ table.td.center {text-align : center;}
   Decomposition of {{new_name}} into {{ KNOWL('mf.elliptic.hecke-orbits',title='irreducible Hecke orbits')}}
 </h2>
 {% if  space.hecke_orbits=={} %}
-   Problem with Hecke orbits in the datbase!
+   Problem with Hecke orbits in the database!
 {% else %}
 <table>
   <thead>
@@ -68,7 +68,7 @@ table.td.center {text-align : center;}
        {% set f = space.hecke_orbits[label] %}
        <tr>
       <td><a href="{{f.url() }}">{{ f.hecke_orbit_label }}</a></td>
-      <td align="center">
+      <td align="center" valign="top">
         {{ f.dimension }}</td>
 	<td align="center">
         {% if f.coefficient_field.lmfdb_label == '1.1.1.1'%}


### PR DESCRIPTION
Fixes #710. On mf pages with very large q-exps, the name of the form, field of coeffs and dimension are now vertically aligned with the top of the q-exp (instead of the centre). Cf. 11/10/4 or 23/12/1 for instance.